### PR TITLE
Fix swiftformat lint errors and disable unwanted rules

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,6 +1,9 @@
 --disable redundantSelf
 --disable redundantFileprivate
 --disable wrapMultilineStatementBraces
+--disable docComments
+--disable wrapPropertyBodies
+--disable wrapFunctionBodies
 --extensionacl on-declarations
 --hexgrouping 2
 --ifdef noindent

--- a/Rewind/MapView/AnnotationViews/ClusterAnnotationView.swift
+++ b/Rewind/MapView/AnnotationViews/ClusterAnnotationView.swift
@@ -7,7 +7,6 @@
 
 import MapKit
 import UIKit
-
 import VGSL
 
 final class ClusterAnnotationView: MKAnnotationView {

--- a/Rewind/Model/AppGraph.swift
+++ b/Rewind/Model/AppGraph.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import UIKit
-
 import VGSL
 
 @MainActor

--- a/Rewind/Model/AppModel.swift
+++ b/Rewind/Model/AppModel.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import SwiftUI
-
 import VGSL
 
 typealias AppModel = Reducer<AppState, AppAction>

--- a/Rewind/Model/CameraSession.swift
+++ b/Rewind/Model/CameraSession.swift
@@ -7,7 +7,6 @@
 
 import AVFoundation
 import SwiftUI
-
 import VGSL
 
 /// Manages the AVFoundation camera capture session lifecycle, including session setup,

--- a/Rewind/Model/ComparisonModel.swift
+++ b/Rewind/Model/ComparisonModel.swift
@@ -7,9 +7,8 @@
 
 import AVFoundation
 import SwiftUI
-import WebKit
-
 import VGSL
+import WebKit
 
 typealias ComparisonModel = Reducer<ComparisonState, ComparisonAction>
 typealias ComparisonViewStore = ViewStore<ComparisonState, ComparisonAction.External>

--- a/Rewind/Model/Data Types/ModelCluster.swift
+++ b/Rewind/Model/Data Types/ModelCluster.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-
 import VGSL
 
 extension Model {
@@ -32,10 +31,6 @@ extension Model {
 }
 
 extension Model.Cluster: Hashable {
-  static func ==(lhs: Self, rhs: Self) -> Bool {
-    lhs.preview == rhs.preview && lhs.coordinate == rhs.coordinate && lhs.count == rhs.count
-  }
-
   func hash(into hasher: inout Hasher) {
     hasher.combine(preview)
     hasher.combine(coordinate)

--- a/Rewind/Model/ImageListModel.swift
+++ b/Rewind/Model/ImageListModel.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import SwiftUI
-
 import VGSL
 
 typealias ImageListModel = Reducer<ImageListState, ImageListAction>

--- a/Rewind/Model/ImageLoader.swift
+++ b/Rewind/Model/ImageLoader.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import UIKit
-
 import VGSL
 
 final class ImageLoader {

--- a/Rewind/Model/LocalClustering.swift
+++ b/Rewind/Model/LocalClustering.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import MapKit
-
 import VGSL
 
 struct ClusteringCell: Hashable {

--- a/Rewind/Model/SearchModel.swift
+++ b/Rewind/Model/SearchModel.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import MapKit
-
 import VGSL
 
 typealias SearchModel = Reducer<SearchState, SearchAction>

--- a/Rewind/Utils/DelayedModifier.swift
+++ b/Rewind/Utils/DelayedModifier.swift
@@ -54,7 +54,6 @@ private struct DelayedContainer<
 }
 
 extension View {
-  @ViewBuilder
   func delayedModifier<T: Equatable>(
     value: T,
     delay: TimeInterval,

--- a/Rewind/Utils/Reducer.swift
+++ b/Rewind/Utils/Reducer.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-
 import VGSL
 
 @preconcurrency @MainActor

--- a/Rewind/Utils/ViewStore.swift
+++ b/Rewind/Utils/ViewStore.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import SwiftUI
-
 import VGSL
 
 @dynamicMemberLookup

--- a/Rewind/View/ImageDetailsView.swift
+++ b/Rewind/View/ImageDetailsView.swift
@@ -195,7 +195,6 @@ struct ImageDetailsView: View {
     .textSelection(.enabled)
   }
 
-  @ViewBuilder
   private var title: some View {
     HStack {
       VStack(alignment: .leading, spacing: 5) {

--- a/Rewind/View/MapControls.swift
+++ b/Rewind/View/MapControls.swift
@@ -48,7 +48,8 @@ struct MapControls: View {
         pullingProgress: $pullingProgress,
         minPullLength: 300,
         onPull: { appStore(.imageList(.presentCurrentRegionImages(
-          source: RootView.TransitionSource.pullUpCard)))
+          source: RootView.TransitionSource.pullUpCard
+        )))
         }
       )
     }
@@ -190,7 +191,6 @@ struct MapControls: View {
     }
   }
 
-  @ViewBuilder
   private func makeBottomScrollButton(
     iconName: String,
     sourceID: String,


### PR DESCRIPTION
Disable docComments, wrapPropertyBodies, wrapFunctionBodies rules. Apply remaining formatting fixes (import sorting, blank lines).