### PR TITLE
feat: Make date picker interactive in onboarding

### DIFF
--- a/Rewind/View/Onboarding/AnnotationsScreen.swift
+++ b/Rewind/View/Onboarding/AnnotationsScreen.swift
@@ -11,6 +11,9 @@ import SwiftUI
 struct AnnotationsScreen: View {
   var goNext: () -> Void
 
+  /// Interactive year range for the onboarding date picker demo
+  @State private var yearRange: ClosedRange<Int> = 1826...2000
+
   var body: some View {
     VStack(alignment: .leading) {
       VStack(alignment: .leading, spacing: 8) {
@@ -61,8 +64,7 @@ struct AnnotationsScreen: View {
           VStack {
             Text("onboarding_date")
             Divider()
-            YearSelector(yearRange: .constant(1826...2000))
-              .allowsHitTesting(false)
+            YearSelector(yearRange: $yearRange)
           }
           .onboardingCard()
 


### PR DESCRIPTION
## Summary

Implements #107

This PR makes the date picker in the onboarding AnnotationsScreen interactive, allowing users to try out the year range selector during their first app experience.

## Changes

- Added `@State private var yearRange` to `AnnotationsScreen`
- Replaced the constant binding with the state binding for `YearSelector`
- Removed `.allowsHitTesting(false)` modifier that was disabling interaction

## Testing

1. Run the app (or reset onboarding state)
2. Navigate to the annotations screen in onboarding
3. Try dragging the year range slider - it should now respond to touch

## Screenshots

The change is subtle - the date picker now responds to user interaction instead of being static.

## Note

Tested in simulator. The previous contributor mentioned they couldn't work on this as they have Windows - I was able to test on macOS with the iOS simulator.