### PR TITLE
scroll image list to top on sort change

### DIFF
--- a/Rewind/View/ImageList.swift
+++ b/Rewind/View/ImageList.swift
@@ -14,6 +14,9 @@ struct ImageList: View {
   @Namespace
   private var namespace
 
+  @State
+  private var scrollPosition = ScrollPosition()
+
   var body: some View {
     NavigationStack {
       content
@@ -41,6 +44,12 @@ struct ImageList: View {
           items
         }
         .padding(.horizontal, 16)
+      }
+      .scrollPosition($scrollPosition)
+      .onChange(of: viewStore.sorting) { _, _ in
+        withAnimation {
+          scrollPosition.scrollTo(edge: .top)
+        }
       }
     } else {
       ZStack {


### PR DESCRIPTION
## Summary
- When the user changes the sort order in the image list toolbar, scroll the grid back to the top with a light animation
- Uses iOS 18+ `ScrollPosition` API

## Test plan
- [x] Open an image list with enough items to scroll
- [x] Scroll partway down, then change the sorting via the toolbar menu
- [x] List smoothly scrolls to the top after the new sort is applied
- [x] Empty list state still renders correctly (no ScrollView, no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)